### PR TITLE
1.1.8 : 主要改动是加入了 _all 的支持

### DIFF
--- a/doc/Query.md
+++ b/doc/Query.md
@@ -29,6 +29,7 @@ HTTP POST as `@RequestBody` is recommended:
             "_ne": "",
             "_in": [],
             "_nin": [],
+            "_all": [],
             "_regex": "",
             "_like": "",
             "_exists": true,

--- a/doc/Query.zh-CN.md
+++ b/doc/Query.zh-CN.md
@@ -29,6 +29,7 @@
             "_ne": "",
             "_in": [],
             "_nin": [],
+            "_all": [],
             "_regex": "",
             "_like": "",
             "_exists": true,

--- a/eaphone-spring-data-query-commons/pom.xml
+++ b/eaphone-spring-data-query-commons/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.eaphonetech</groupId>
 		<artifactId>eaphone-spring-data-query-parent</artifactId>
-		<version>2.0.2</version>
+		<version>2.0.3-SNAPSNOT</version>
 	</parent>
 
 	<artifactId>eaphone-spring-data-query-commons</artifactId>

--- a/eaphone-spring-data-query-commons/src/main/java/com/eaphonetech/common/datatables/model/mapping/ColumnType.java
+++ b/eaphone-spring-data-query-commons/src/main/java/com/eaphonetech/common/datatables/model/mapping/ColumnType.java
@@ -14,12 +14,14 @@ public abstract class ColumnType {
 	private static final String CODE_DOUBLE = "double";
 	private static final String CODE_DATE = "date";
 	private static final String CODE_BOOLEAN = "boolean";
+	private static final String CODE_NESTED_OBJECT = "object";
 
 	public static final ColumnType STRING = new StringColumnType();
 	public static final ColumnType INTEGER = new IntegerColumnType();
 	public static final ColumnType DOUBLE = new DoubleColumnType();
 	public static final ColumnType DATE = new DateColumnType();
 	public static final ColumnType BOOLEAN = new BooleanColumnType();
+	public static final ColumnType NESTED_OBJECT = new NestedObjectColumnType();
 
 	private String code;
 	private boolean comparable;
@@ -51,19 +53,18 @@ public abstract class ColumnType {
 
 		if (c.isPrimitive()) {
 			// boolean, byte, char, short, int, long, float, and double.
-			if (is(c, char.class)) {
-				// TODO: whether type 'char' should be STRING or INTEGER?
-				return STRING;
-			} else if (is(c, byte.class, short.class, int.class, long.class)) {
+			 if (is(c, byte.class, char.class, short.class, int.class, long.class)) {
 				return INTEGER;
 			} else if (is(c, float.class, double.class)) {
 				return DOUBLE;
 			} else if (is(c, boolean.class)) {
 				return BOOLEAN;
 			} else {
-				// unexpected primitive type
+				// unexpected primitive type: void
 				throw new IllegalArgumentException(String.format("unexpected type '%s'", c.toString()));
 			}
+		} else if (c.isEnum()) {
+			return STRING;
 		} else if (c.isArray()) {
 			// TODO how to check array?
 			// c.getComponentType() is type of array item;
@@ -79,6 +80,9 @@ public abstract class ColumnType {
 				return BOOLEAN;
 			} else if (is(c, Date.class)) {
 				return DATE;
+			} else {
+				// nested class
+				return NESTED_OBJECT;
 			}
 		}
 		return STRING;
@@ -159,6 +163,17 @@ public abstract class ColumnType {
 		@Override
 		public Object tryConvert(Object o) {
 			return o == null ? null : Boolean.parseBoolean(o.toString());
+		}
+	}
+
+	static final class NestedObjectColumnType extends ColumnType {
+		NestedObjectColumnType() {
+			super(CODE_NESTED_OBJECT, false);
+		}
+
+		@Override
+		public Object tryConvert(Object o) {
+			return o == null ? null : o;
 		}
 	}
 

--- a/eaphone-spring-data-query-commons/src/main/java/com/eaphonetech/common/datatables/model/mapping/filter/QueryFilter.java
+++ b/eaphone-spring-data-query-commons/src/main/java/com/eaphonetech/common/datatables/model/mapping/filter/QueryFilter.java
@@ -14,6 +14,7 @@ public class QueryFilter {
     private Object _ne;
     private List<Object> _in;
     private List<Object> _nin;
+    private List<Object> _all;
     private String _regex;
     private String _like;
     private Boolean _exists;

--- a/eaphone-spring-data-query-jpa/pom.xml
+++ b/eaphone-spring-data-query-jpa/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.eaphonetech</groupId>
 		<artifactId>eaphone-spring-data-query-parent</artifactId>
-		<version>2.0.2</version>
+		<version>2.0.3-SNAPSNOT</version>
 	</parent>
 
 	<artifactId>eaphone-spring-data-query-jpa</artifactId>
@@ -22,7 +22,7 @@
 			<groupId>com.eaphonetech</groupId>
 			<artifactId>eaphone-spring-data-query-commons</artifactId>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>

--- a/eaphone-spring-data-query-jpa/src/main/java/com/eaphonetech/common/datatables/jpa/AbstractPredicateBuilder.java
+++ b/eaphone-spring-data-query-jpa/src/main/java/com/eaphonetech/common/datatables/jpa/AbstractPredicateBuilder.java
@@ -6,7 +6,6 @@ import java.util.Map;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.lang.NonNull;
 
 import com.eaphonetech.common.datatables.model.mapping.CountInput;
 import com.eaphonetech.common.datatables.model.mapping.QueryInput;
@@ -71,7 +70,7 @@ abstract class AbstractPredicateBuilder<T> {
 		if (input.getLimit() == -1) {
 			input.setLimit(Integer.MAX_VALUE);
 		}
-		return new DataTablesPageRequest(input.getOffset(), input.getLimit(), sort);
+		return PageRequest.of(input.getOffset() / input.getLimit(), input.getLimit(), sort);
 	}
 
 	public abstract T build();

--- a/eaphone-spring-data-query-jpa/src/main/java/com/eaphonetech/common/datatables/jpa/repository/EaphoneQueryRepositoryFactoryBean.java
+++ b/eaphone-spring-data-query-jpa/src/main/java/com/eaphonetech/common/datatables/jpa/repository/EaphoneQueryRepositoryFactoryBean.java
@@ -13,7 +13,7 @@ import jakarta.persistence.EntityManager;
 
 /**
  * {@link FactoryBean} creating DataTablesRepositoryFactory instances.
- * 
+ *
  * @author Damien Arrachequesne
  */
 public class EaphoneQueryRepositoryFactoryBean<R extends JpaRepository<T, ID>, T, ID extends Serializable>

--- a/eaphone-spring-data-query-mongodb/pom.xml
+++ b/eaphone-spring-data-query-mongodb/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.eaphonetech</groupId>
 		<artifactId>eaphone-spring-data-query-parent</artifactId>
-		<version>2.0.2</version>
+		<version>2.0.3-SNAPSNOT</version>
 	</parent>
 
 	<artifactId>eaphone-spring-data-query-mongodb</artifactId>

--- a/eaphone-spring-data-query-mongodb/src/main/java/com/eaphonetech/common/datatables/mongodb/repository/QueryUtils.java
+++ b/eaphone-spring-data-query-mongodb/src/main/java/com/eaphonetech/common/datatables/mongodb/repository/QueryUtils.java
@@ -30,6 +30,7 @@ import org.springframework.data.mongodb.core.aggregation.TypedAggregation;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.repository.query.MongoEntityInformation;
+import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 
 import com.eaphonetech.common.datatables.model.mapping.ColumnType;
@@ -76,7 +77,7 @@ public class QueryUtils {
 	}
 
 	/**
-	 * Find one possible field of nested name parts. 
+	 * Find one possible field of nested name parts.
 	 * @param javaType
 	 * @param fieldNameParts
 	 * @param currentIndex
@@ -160,7 +161,7 @@ public class QueryUtils {
 
 	/**
 	 * Recursively get field type
-	 * 
+	 *
 	 * @param javaType
 	 * @param fieldNameParts
 	 * @param currentIndex
@@ -173,13 +174,13 @@ public class QueryUtils {
 	/**
 	 * Determine actual MongoDB field type from input
 	 * (including jackson-databind, etc.)
-	 * 
+	 *
 	 * @param javaType actual java type
 	 * @param fieldName frontend provided field name
 	 * @return
 	 */
 	private static ColumnType getFieldType(Class<?> javaType, String fieldName) {
-		if (javaType == null || StringUtils.isEmpty(fieldName)) {
+		if (javaType == null || ObjectUtils.isEmpty(fieldName)) {
 			return null;
 		}
 
@@ -196,7 +197,7 @@ public class QueryUtils {
 
 	/**
 	 * Recursively get field name
-	 * 
+	 *
 	 * @param javaType
 	 * @param fieldNameParts
 	 * @param currentIndex
@@ -209,13 +210,13 @@ public class QueryUtils {
 	/**
 	 * Determine actual MongoDB field name from input
 	 * (including jackson-databind, etc.)
-	 * 
+	 *
 	 * @param javaType actual java type
 	 * @param fieldName frontend provided field name
 	 * @return
 	 */
 	private static String getFieldName(Class<?> javaType, String fieldName) {
-		if (javaType == null || StringUtils.isEmpty(fieldName)) {
+		if (javaType == null || ObjectUtils.isEmpty(fieldName)) {
 			return null;
 		}
 
@@ -232,7 +233,7 @@ public class QueryUtils {
 
 	/**
 	 * Convert a {@link QueryInput} to Criteia
-	 * 
+	 *
 	 * @param input
 	 * @return
 	 */
@@ -268,6 +269,11 @@ public class QueryUtils {
 
 					if (filter.get_nin() != null) {
 						c.nin(convertArray(type, filter.get_nin()));
+						hasValidCrit = true;
+					}
+
+					if (filter.get_all() != null) {
+						c.all(convertArray(type, filter.get_all()));
 						hasValidCrit = true;
 					}
 
@@ -327,7 +333,7 @@ public class QueryUtils {
 
 	/**
 	 * Creates a '$sort' clause for the given {@link QueryInput}.
-	 * 
+	 *
 	 * @param <T> generic
 	 * @param <ID> generic
 	 * @param entityInformation {@link MongoEntityInformation}
@@ -349,12 +355,12 @@ public class QueryUtils {
 		if (input.getLimit() == -1) {
 			input.setLimit(Integer.MAX_VALUE);
 		}
-		return new DataTablesPageRequest(input.getOffset(), input.getLimit(), sort);
+		return PageRequest.of(input.getOffset() / input.getLimit(), input.getLimit(), sort);
 	}
 
 	/**
 	 * "LIKE" search is converted to $regex
-	 * 
+	 *
 	 * @param filterValue filter value
 	 * @return
 	 */
@@ -438,7 +444,7 @@ public class QueryUtils {
 
 	/**
 	 * Convert {@link QueryInput} to {@link AggregationOperation}[], mainly for column searches.
-	 * 
+	 *
 	 * @param input
 	 * @return
 	 */
@@ -458,7 +464,7 @@ public class QueryUtils {
 	 * Create an {@link TypedAggregation} with specified {@link QueryInput} as filter, plus specified
 	 * {@link AggregationOperation}[], but only act as <code>$count</code>
 	 * <p>This basically creates an aggregation pipeline as follows:</p>
-	 * 
+	 *
 	 * <pre>
 	 * <code>
 	 * [
@@ -467,7 +473,7 @@ public class QueryUtils {
 	 * ]
 	 * </code>
 	 * </pre>
-	 * 
+	 *
 	 * @param entityInformation {@link MongoEntityInformation}
 	 * @param input the {@link QueryInput} mapped from the Ajax request
 	 * @param operations aggregation operations
@@ -491,7 +497,7 @@ public class QueryUtils {
 	/**
 	 * Create an {@link TypedAggregation} with specified {@link QueryInput} as filter, plus specified
 	 * {@link AggregationOperation}[]
-	 * 
+	 *
 	 * @param classOfT
 	 * @param input
 	 * @param pageable
@@ -521,7 +527,7 @@ public class QueryUtils {
 	}
 
 	/**
-	 * 
+	 *
 	 * @param <T>
 	 * @param <ID>
 	 * @param entityInformation
@@ -541,7 +547,7 @@ public class QueryUtils {
 	}
 
 	/**
-	 * 
+	 *
 	 * @param input
 	 * @param entityInformation
 	 * @return

--- a/eaphone-spring-data-query-samples/pom.xml
+++ b/eaphone-spring-data-query-samples/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
@@ -48,7 +50,7 @@
 			<optional>true</optional>
 		</dependency>
 
-        <!-- mongo-java-server for fake mongodb -->
+		<!-- mongo-java-server for fake mongodb -->
 		<dependency>
 			<groupId>de.bwaldvogel</groupId>
 			<artifactId>mongo-java-server</artifactId>
@@ -75,6 +77,24 @@
 		<dependency>
 			<groupId>org.webjars</groupId>
 			<artifactId>webjars-locator-core</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.webjars</groupId>
+			<artifactId>jquery</artifactId>
+			<version>3.6.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.webjars</groupId>
+			<artifactId>bootstrap</artifactId>
+			<version>4.6.1</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.webjars</groupId>
+			<artifactId>highlightjs</artifactId>
+			<version>10.1.2</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/eaphone-spring-data-query-samples/pom.xml
+++ b/eaphone-spring-data-query-samples/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.eaphonetech</groupId>
 		<artifactId>eaphone-spring-data-query-parent</artifactId>
-		<version>2.0.2</version>
+		<version>2.0.3-SNAPSNOT</version>
 	</parent>
 
 	<artifactId>eaphone-spring-data-query-samples</artifactId>

--- a/eaphone-spring-data-query-samples/src/main/java/com/eaphonetech/common/datatables/samples/mongo/document/Order.java
+++ b/eaphone-spring-data-query-samples/src/main/java/com/eaphonetech/common/datatables/samples/mongo/document/Order.java
@@ -1,10 +1,10 @@
 package com.eaphonetech.common.datatables.samples.mongo.document;
 
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
-import java.util.HashSet;
+import java.util.List;
 import java.util.Random;
-import java.util.Set;
 
 import org.bson.types.ObjectId;
 import org.springframework.data.annotation.Id;
@@ -47,7 +47,7 @@ public class Order {
 	private double price;
 
 	@JsonView(QueryOutput.View.class)
-	private Set<OrderItem> items;
+	private List<OrderItem> items;
 
 	@Transient
 	public static Order random() {
@@ -62,28 +62,26 @@ public class Order {
 
 		o.isValid = r.nextBoolean();
 
-		o.amount = r.nextInt(25);
-
 		o.price = Math.round(100.0 * 100.0 * r.nextDouble()) / 100.0;
 
-		Set<OrderItem> items = new HashSet<>();
-		for (int i = 0; i < r.nextInt(8); i++) {
-			int amount = r.nextInt(25);
-			double price = Math.round(100.0 * 100.0 * r.nextDouble()) / 100.0;
+		List<OrderItem> items = new ArrayList<>();
+		int itemsCount = r.nextInt(5);
+		int preciseTotalPrice = 0;
+		for (int i = 0; i < itemsCount; i++) {
+			int preciseItemPrice = r.nextInt(10000);
 
 			OrderItem item = new OrderItem();
 			item.setId(new ObjectId().toHexString());
 			item.setName(o.getOrderNumber() + "_" + i);
-			item.setAmount(amount);
-			item.setPrice(price);
-			item.setDate(o.getDate());
-			item.setValid(o.isValid());
+			item.setPrice((double) preciseItemPrice / 100.0);
 			items.add(item);
 
-			o.setAmount(o.getAmount() + amount);
-			o.setPrice(o.getPrice() + price);
+			preciseTotalPrice += preciseItemPrice;
 		}
+		o.setPrice((double) preciseTotalPrice / 100.0);
 		o.setItems(items);
+
+		o.amount = itemsCount;
 
 		return o;
 	}

--- a/eaphone-spring-data-query-samples/src/main/java/com/eaphonetech/common/datatables/samples/mongo/document/OrderItem.java
+++ b/eaphone-spring-data-query-samples/src/main/java/com/eaphonetech/common/datatables/samples/mongo/document/OrderItem.java
@@ -1,11 +1,8 @@
 package com.eaphonetech.common.datatables.samples.mongo.document;
 
-import java.util.Date;
-
 import org.springframework.data.mongodb.core.mapping.Field;
 
 import com.eaphonetech.common.datatables.model.mapping.QueryOutput;
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonView;
 
 import lombok.Data;
@@ -21,16 +18,5 @@ public class OrderItem {
 	private String name;
 
 	@JsonView(QueryOutput.View.class)
-	private int amount;
-
-	@JsonView(QueryOutput.View.class)
 	private double price;
-
-	@JsonFormat(pattern = "yyyy-MM-dd")
-	@JsonView(QueryOutput.View.class)
-	private Date date;
-
-	@JsonView(QueryOutput.View.class)
-	private boolean isValid;
-
 }

--- a/eaphone-spring-data-query-samples/src/main/resources/application.properties
+++ b/eaphone-spring-data-query-samples/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 logging.level.com.eaphonetech.common.datatables=DEBUG
+logging.level.org.springframework.data.mongodb.core=DEBUG
 
 spring.jpa.show-sql=true
 spring.jpa.hibernate.ddl-auto=create

--- a/eaphone-spring-data-query-samples/src/main/resources/static/index.html
+++ b/eaphone-spring-data-query-samples/src/main/resources/static/index.html
@@ -3,12 +3,12 @@
 
 <head>
   <title>Eaphone Query Example</title>
-  <!--
   <link rel="stylesheet" href="/webjars/bootstrap/css/bootstrap.min.css" />
-  <link rel="stylesheet" href="/webjars/highlightjs/styles/solarized-light.css" />
-  -->
+  <link rel="stylesheet" href="/webjars/highlightjs/styles/solarized-light.min.css" />
+  <!--
   <link href="https://cdn.bootcss.com/bootstrap/4.1.1/css/bootstrap.min.css" rel="stylesheet">
   <link href="https://cdn.bootcss.com/highlight.js/9.12.0/styles/solarized-light.min.css" rel="stylesheet">
+  -->
   <link rel="stylesheet" href="css/style.css">
 </head>
 
@@ -45,7 +45,7 @@
             <div class="card mb-4">
               <h5 class="card-header">Rendered Grid</h5>
               <div class="card-body">
-                <table class="table table-bordered table-striped table-sm">
+                <table class="table table-bordered table-striped table-sm text-center">
                   <thead>
                     <tr>
                       <th scope="col">i</th>
@@ -75,9 +75,15 @@
       </div>
     </div>
   </div>
+  
+  <script src="/webjars/jquery/jquery.min.js"></script>
+  <script src="/webjars/bootstrap/js/bootstrap.min.js"></script>
+  <script src="/webjars/highlightjs/highlight.min.js"></script>
+  <!--
   <script src="https://cdn.bootcss.com/jquery/3.3.1/jquery.min.js"></script>
   <script src="https://cdn.bootcss.com/bootstrap/4.1.1/js/bootstrap.min.js"></script>
   <script src="https://cdn.bootcss.com/highlight.js/9.12.0/highlight.min.js"></script>
+  -->
   <script type="text/javascript" src="/js/index.js"></script>
 </body>
 

--- a/eaphone-spring-data-query-samples/src/main/resources/static/js/index.js
+++ b/eaphone-spring-data-query-samples/src/main/resources/static/js/index.js
@@ -27,6 +27,26 @@ $(document).ready(function () {
 			}
 		}
 	}, {
+		summary: 'Single regex filter',
+		description: 'Filter with regular expression',
+		value: {
+			where: {
+				orderNumber: {
+					'_regex': 'O1..[25].*'
+				}
+			}
+		}
+	}, {
+		summary: 'SQL Like',
+		description: 'Query using SQL like (%)',
+		value: {
+			where: {
+				"orderNumber": {
+					"_like": "O100%"
+				}
+			}
+		}
+	}, {
 		summary: 'Single comparison filter',
 		description: 'Comparison filter on single column',
 		value: {
@@ -47,12 +67,22 @@ $(document).ready(function () {
 			}
 		}
 	}, {
+		summary: 'Boolean search',
+		description: 'Search with boolean values',
+		value: {
+			where: {
+				isValid: {
+					'_eq': true
+				}
+			}
+		}
+	}, {
 		summary: 'Enumeration (in)',
 		description: 'Enumeration with number',
 		value: {
 			where: {
 				amount: {
-					'_in': [5, 9, 13]
+					'_in': [2, 3, 5]
 				}
 			}
 		}
@@ -62,22 +92,32 @@ $(document).ready(function () {
 		value: {
 			where: {
 				price: {
-					'_gte': 10,
-					'_lt': 20.5
+					'_gte': 50,
+					'_lt': 200
 				}
 			}
 		}
 	}, {
 		summary: 'Multiple columns',
-		description: 'More where on multiple columns',
+		description: 'More criteria on multiple columns (AND)',
 		value: {
 			where: {
 				date: {
 					'_gt': '2012-01-01'
 				},
 				price: {
-					'_gte': 10,
-					'_lt': 20.5
+					'_gte': 50,
+					'_lt': 200
+				}
+			}
+		}
+	}, {
+		summary: 'Empty array',
+		description: 'Search for empty array',
+		value: {
+			where: {
+				items: {
+					'_eq': []
 				}
 			}
 		}
@@ -102,16 +142,6 @@ $(document).ready(function () {
 			}, {
 				'price': 'asc'
 			}]
-		}
-	}, {
-		summary: 'Like',
-		description: 'SQL like',
-		value: {
-			where: {
-				"orderNumber": {
-					"_like": "O100%"
-				}
-			}
 		}
 	}];
 	

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
 	<groupId>com.eaphonetech</groupId>
 	<artifactId>eaphone-spring-data-query-parent</artifactId>
-	<version>2.0.2</version>
+	<version>2.0.3-SNAPSNOT</version>
 	<packaging>pom</packaging>
 
 	<organization>
@@ -63,7 +63,7 @@
 				<artifactId>mongo-java-server</artifactId>
 				<version>1.45.0</version>
 			</dependency>
-			
+
 			<!-- h2 for fake mysql -->
 			<dependency>
 				<groupId>com.h2database</groupId>


### PR DESCRIPTION
主要原因是 mongodb 的 `$eq` 当值是数组时，会作为 list 处理（值和顺序完全匹配）。因此在某些查询时，用 $or 会很难拼接。

例如：

```javascript
search: {
    tip: {
        _all: ['enum1', 'enum2']
    }
}
```

